### PR TITLE
Better error message when running on Android or WebVR

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ function lovr.update(dt)
 end
 ```
 
+lovr-mouse can only run on systems where LÖVR uses both LuaJIT and GLFW. If your project needs to be compatible with Android or WebVR, you can optionally include lovr-keyboard with:
+
+```lua
+if type(jit) == 'table' and lovr.getOS() ~= 'Android' and lovr.getOS() ~= 'Web' then
+	lovr.keyboard = require 'lovr-mouse'
+end
+```
+
 API
 ---
 

--- a/lovr-mouse.lua
+++ b/lovr-mouse.lua
@@ -1,4 +1,6 @@
-local ffi = require 'ffi'
+local ffi = assert(type(jit) == 'table' and               -- Only run if we have LuaJIT
+  lovr.getOS() ~= 'Android' and lovr.getOS() ~= 'Web' and -- and also GLFW
+  require 'ffi', "lovr-mouse cannot run on this platform")
 local C = ffi.os == 'Windows' and ffi.load('glfw3') or ffi.C
 
 ffi.cdef [[


### PR DESCRIPTION
"No LuaJIT" should catch WebVR, and then there's a special case for oculusmobile (our only non-GLFW platform).