### PR TITLE
Update lovr-mouse.lua

### DIFF
--- a/lovr-mouse.lua
+++ b/lovr-mouse.lua
@@ -107,7 +107,7 @@ end
 
 function mouse.newCursor(source, hotx, hoty)
   if type(source) == 'string' or tostring(source) == 'Blob' then
-    source = lovr.data.newImage(source, false)
+    source = lovr.data.newImage(source)
   else
     assert(tostring(source) == 'Image', 'Bad argument #1 to newCursor (Image expected)')
   end


### PR DESCRIPTION
`lovr.data.newImage` no longer takes a `flip` parameter. This change stops passing `false` to it.